### PR TITLE
Move download button to the Tab Header

### DIFF
--- a/webpack/ForemanYupana/Components/ReportGenerate/__tests__/__snapshots__/ReportGenerate.test.js.snap
+++ b/webpack/ForemanYupana/Components/ReportGenerate/__tests__/__snapshots__/ReportGenerate.test.js.snap
@@ -6,6 +6,7 @@ exports[`ReportGenerate rendering render with Props 1`] = `
 >
   <TabHeader
     exitCode={0}
+    onDownload={null}
     onRestart={[Function]}
   />
   <TabBody
@@ -27,6 +28,7 @@ exports[`ReportGenerate rendering render without Props 1`] = `
 >
   <TabHeader
     exitCode={0}
+    onDownload={null}
     onRestart={[Function]}
   />
   <TabBody

--- a/webpack/ForemanYupana/Components/ReportUpload/ReportUpload.js
+++ b/webpack/ForemanYupana/Components/ReportUpload/ReportUpload.js
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types';
 import { noop } from 'patternfly-react';
 import TabContainer from '../TabContainer';
 import TabHeader from '../TabHeader';
-import TabFooter from '../TabFooter';
 import TabBody from '../TabBody';
-import FileDownload from '../FileDownload';
 import './reportUpload.scss';
 
 const ReportUpload = ({
@@ -18,16 +16,17 @@ const ReportUpload = ({
   error,
 }) => (
   <TabContainer className="report-upload">
-    <TabHeader exitCode={exitCode} onRestart={restartProcess} />
+    <TabHeader
+      exitCode={exitCode}
+      onRestart={restartProcess}
+      onDownload={downloadReports}
+    />
     <TabBody
       loading={loading}
       logs={logs}
       completed={completed}
       error={error}
     />
-    <TabFooter>
-      <FileDownload onClick={downloadReports} />
-    </TabFooter>
   </TabContainer>
 );
 

--- a/webpack/ForemanYupana/Components/ReportUpload/__tests__/__snapshots__/ReportUpload.test.js.snap
+++ b/webpack/ForemanYupana/Components/ReportUpload/__tests__/__snapshots__/ReportUpload.test.js.snap
@@ -6,6 +6,7 @@ exports[`ReportUpload rendering render with Props 1`] = `
 >
   <TabHeader
     exitCode={0}
+    onDownload={[Function]}
     onRestart={[Function]}
   />
   <TabBody
@@ -18,11 +19,6 @@ exports[`ReportUpload rendering render with Props 1`] = `
       ]
     }
   />
-  <TabFooter>
-    <FileDownload
-      onClick={[Function]}
-    />
-  </TabFooter>
 </TabContainer>
 `;
 
@@ -32,6 +28,7 @@ exports[`ReportUpload rendering render without Props 1`] = `
 >
   <TabHeader
     exitCode={0}
+    onDownload={[Function]}
     onRestart={[Function]}
   />
   <TabBody
@@ -44,10 +41,5 @@ exports[`ReportUpload rendering render without Props 1`] = `
       ]
     }
   />
-  <TabFooter>
-    <FileDownload
-      onClick={[Function]}
-    />
-  </TabFooter>
 </TabContainer>
 `;

--- a/webpack/ForemanYupana/Components/TabHeader/TabHeader.js
+++ b/webpack/ForemanYupana/Components/TabHeader/TabHeader.js
@@ -1,29 +1,44 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop, Grid, Button } from 'patternfly-react';
+import { noop, Grid, Button, ButtonGroup, Icon } from 'patternfly-react';
 import './tabHeader.scss';
 
-const TabHeader = ({ exitCode, onRestart }) => (
-  <Grid.Row className="tab-header">
-    <Grid.Col sm={8}>
-      <h1># Exit Code: {exitCode}</h1>
-    </Grid.Col>
-    <Grid.Col sm={4}>
-      <Button bsStyle="primary" onClick={onRestart}>
-        Restart
+const TabHeader = ({ exitCode, onRestart, onDownload }) => {
+  const restartButton = (
+    <Button bsStyle="primary" onClick={onRestart}>
+      Restart
+    </Button>
+  );
+  const buttons = onDownload ? (
+    <ButtonGroup>
+      {restartButton}
+      <Button onClick={onDownload}>
+        Download Report <Icon name="download" />
       </Button>
-    </Grid.Col>
-  </Grid.Row>
-);
+    </ButtonGroup>
+  ) : (
+    restartButton
+  );
+  return (
+    <Grid.Row className="tab-header">
+      <Grid.Col sm={7}>
+        <p># Exit Code: {exitCode}</p>
+      </Grid.Col>
+      <Grid.Col sm={5}>{buttons}</Grid.Col>
+    </Grid.Row>
+  );
+};
 
 TabHeader.propTypes = {
   onRestart: PropTypes.func,
+  onDownload: PropTypes.func,
   exitCode: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 TabHeader.defaultProps = {
   onRestart: noop,
   exitCode: '',
+  onDownload: null,
 };
 
 export default TabHeader;

--- a/webpack/ForemanYupana/Components/TabHeader/__tests__/__snapshots__/TabHeader.test.js.snap
+++ b/webpack/ForemanYupana/Components/TabHeader/__tests__/__snapshots__/TabHeader.test.js.snap
@@ -9,16 +9,16 @@ exports[`TabHeader rendering render without Props 1`] = `
   <Col
     bsClass="col"
     componentClass="div"
-    sm={8}
+    sm={7}
   >
-    <h1>
+    <p>
       # Exit Code: 
-    </h1>
+    </p>
   </Col>
   <Col
     bsClass="col"
     componentClass="div"
-    sm={4}
+    sm={5}
   >
     <Button
       active={false}

--- a/webpack/ForemanYupana/Components/TabHeader/tabHeader.scss
+++ b/webpack/ForemanYupana/Components/TabHeader/tabHeader.scss
@@ -3,7 +3,12 @@
     margin-top: 0;
   }
 
-  button {
+  p {
+    font-size: 16px;
+  }
+
+  button,
+  .btn-group {
     float: right;
   }
 }


### PR DESCRIPTION
Now while switching between the inner tabs, the tab container height won't jump because of the additional button in the uploading tab.

![Selection_179](https://user-images.githubusercontent.com/26363699/62228335-2492ae80-b3c6-11e9-8f52-87aafdeee8f3.png)
