### PR TITLE
Show terminal spinner when exit code is 'running'

### DIFF
--- a/webpack/ForemanYupana/Components/Dashboard/Dashboard.js
+++ b/webpack/ForemanYupana/Components/Dashboard/Dashboard.js
@@ -77,7 +77,6 @@ Dashboard.propTypes = {
   setActiveTab: PropTypes.func,
   uploading: PropTypes.shape({
     exitCode: PropTypes.string,
-    loading: PropTypes.bool,
     logs: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.string),
       PropTypes.string,
@@ -88,7 +87,6 @@ Dashboard.propTypes = {
   }),
   generating: PropTypes.shape({
     exitCode: PropTypes.string,
-    loading: PropTypes.bool,
     logs: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.string),
       PropTypes.string,

--- a/webpack/ForemanYupana/Components/ReportGenerate/ReportGenerate.fixtures.js
+++ b/webpack/ForemanYupana/Components/ReportGenerate/ReportGenerate.fixtures.js
@@ -1,7 +1,6 @@
 import { noop } from 'patternfly-react';
 
-export const exitCode = 0;
-export const loading = false;
+export const exitCode = 'exit 0';
 export const logs = ['No running process'];
 export const completed = 0;
 export const restartProcess = noop;
@@ -9,7 +8,6 @@ export const error = null;
 export const processScheduledTime = 'some-time';
 export const props = {
   exitCode,
-  loading,
   logs,
   completed,
   restartProcess,

--- a/webpack/ForemanYupana/Components/ReportGenerate/ReportGenerate.js
+++ b/webpack/ForemanYupana/Components/ReportGenerate/ReportGenerate.js
@@ -8,7 +8,6 @@ import './reportGenerate.scss';
 
 const ReportGenerate = ({
   exitCode,
-  loading,
   logs,
   completed,
   error,
@@ -17,7 +16,7 @@ const ReportGenerate = ({
   <TabContainer className="report-generate">
     <TabHeader exitCode={exitCode} onRestart={restartProcess} />
     <TabBody
-      loading={loading}
+      exitCode={exitCode}
       logs={logs}
       completed={completed}
       error={error}
@@ -26,8 +25,7 @@ const ReportGenerate = ({
 );
 
 ReportGenerate.propTypes = {
-  exitCode: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  loading: PropTypes.bool,
+  exitCode: PropTypes.string,
   logs: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.string,
@@ -38,8 +36,7 @@ ReportGenerate.propTypes = {
 };
 
 ReportGenerate.defaultProps = {
-  exitCode: 0,
-  loading: false,
+  exitCode: '',
   logs: null,
   completed: 0,
   error: null,

--- a/webpack/ForemanYupana/Components/ReportGenerate/__tests__/__snapshots__/ReportGenerate.test.js.snap
+++ b/webpack/ForemanYupana/Components/ReportGenerate/__tests__/__snapshots__/ReportGenerate.test.js.snap
@@ -5,14 +5,14 @@ exports[`ReportGenerate rendering render with Props 1`] = `
   className="report-generate"
 >
   <TabHeader
-    exitCode={0}
+    exitCode="exit 0"
     onDownload={null}
     onRestart={[Function]}
   />
   <TabBody
     completed={0}
     error={null}
-    loading={false}
+    exitCode="exit 0"
     logs={
       Array [
         "No running process",
@@ -27,14 +27,14 @@ exports[`ReportGenerate rendering render without Props 1`] = `
   className="report-generate"
 >
   <TabHeader
-    exitCode={0}
+    exitCode=""
     onDownload={null}
     onRestart={[Function]}
   />
   <TabBody
     completed={0}
     error={null}
-    loading={false}
+    exitCode=""
     logs={null}
   />
 </TabContainer>

--- a/webpack/ForemanYupana/Components/ReportUpload/ReportUpload.fixtures.js
+++ b/webpack/ForemanYupana/Components/ReportUpload/ReportUpload.fixtures.js
@@ -1,8 +1,7 @@
 import { noop } from 'patternfly-react';
 
 export const files = ['some-file'];
-export const exitCode = 0;
-export const loading = false;
+export const exitCode = 'exit 0';
 export const logs = ['No running process'];
 export const completed = 0;
 export const restartProcess = noop;
@@ -11,7 +10,6 @@ export const error = null;
 export const props = {
   files,
   exitCode,
-  loading,
   logs,
   completed,
   restartProcess,

--- a/webpack/ForemanYupana/Components/ReportUpload/ReportUpload.js
+++ b/webpack/ForemanYupana/Components/ReportUpload/ReportUpload.js
@@ -8,7 +8,6 @@ import './reportUpload.scss';
 
 const ReportUpload = ({
   exitCode,
-  loading,
   logs,
   completed,
   downloadReports,
@@ -22,7 +21,7 @@ const ReportUpload = ({
       onDownload={downloadReports}
     />
     <TabBody
-      loading={loading}
+      exitCode={exitCode}
       logs={logs}
       completed={completed}
       error={error}
@@ -31,8 +30,7 @@ const ReportUpload = ({
 );
 
 ReportUpload.propTypes = {
-  exitCode: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  loading: PropTypes.bool,
+  exitCode: PropTypes.string,
   logs: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.string,
@@ -44,8 +42,7 @@ ReportUpload.propTypes = {
 };
 
 ReportUpload.defaultProps = {
-  exitCode: 0,
-  loading: false,
+  exitCode: '',
   logs: null,
   completed: 0,
   restartProcess: noop,

--- a/webpack/ForemanYupana/Components/ReportUpload/__tests__/__snapshots__/ReportUpload.test.js.snap
+++ b/webpack/ForemanYupana/Components/ReportUpload/__tests__/__snapshots__/ReportUpload.test.js.snap
@@ -5,14 +5,14 @@ exports[`ReportUpload rendering render with Props 1`] = `
   className="report-upload"
 >
   <TabHeader
-    exitCode={0}
+    exitCode="exit 0"
     onDownload={[Function]}
     onRestart={[Function]}
   />
   <TabBody
     completed={0}
     error={null}
-    loading={false}
+    exitCode="exit 0"
     logs={
       Array [
         "No running process",
@@ -27,14 +27,14 @@ exports[`ReportUpload rendering render without Props 1`] = `
   className="report-upload"
 >
   <TabHeader
-    exitCode={0}
+    exitCode=""
     onDownload={[Function]}
     onRestart={[Function]}
   />
   <TabBody
     completed={0}
     error={null}
-    loading={false}
+    exitCode=""
     logs={null}
   />
 </TabContainer>

--- a/webpack/ForemanYupana/Components/TabBody/TabBody.js
+++ b/webpack/ForemanYupana/Components/TabBody/TabBody.js
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 import { Grid } from 'patternfly-react';
 import Terminal from '../Terminal';
 
-const TabBody = ({ loading, logs, error }) => (
+const TabBody = ({ exitCode, logs, error }) => (
   <Grid.Row>
-    <Terminal logs={logs} loading={loading} error={error} />
+    <Terminal logs={logs} exitCode={exitCode} error={error} />
   </Grid.Row>
 );
 
 TabBody.propTypes = {
-  loading: PropTypes.bool,
+  exitCode: PropTypes.string,
   logs: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.string,
@@ -19,7 +19,7 @@ TabBody.propTypes = {
 };
 
 TabBody.defaultProps = {
-  loading: false,
+  exitCode: '',
   logs: null,
   error: null,
 };

--- a/webpack/ForemanYupana/Components/TabBody/__tests__/__snapshots__/TabBody.test.js.snap
+++ b/webpack/ForemanYupana/Components/TabBody/__tests__/__snapshots__/TabBody.test.js.snap
@@ -7,7 +7,7 @@ exports[`TabBody rendering render without Props 1`] = `
 >
   <Terminal
     error={null}
-    loading={false}
+    exitCode=""
     logs={null}
   />
 </Row>

--- a/webpack/ForemanYupana/Components/TabHeader/TabHeader.js
+++ b/webpack/ForemanYupana/Components/TabHeader/TabHeader.js
@@ -32,7 +32,7 @@ const TabHeader = ({ exitCode, onRestart, onDownload }) => {
 TabHeader.propTypes = {
   onRestart: PropTypes.func,
   onDownload: PropTypes.func,
-  exitCode: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  exitCode: PropTypes.string,
 };
 
 TabHeader.defaultProps = {

--- a/webpack/ForemanYupana/Components/Terminal/Terminal.fixtures.js
+++ b/webpack/ForemanYupana/Components/Terminal/Terminal.fixtures.js
@@ -5,6 +5,6 @@ export const logs = [
   'writing host 2/1000',
 ];
 
-export const loading = true;
+export const exitCode = 'Running pid 1111111';
 
-export const props = { logs, loading };
+export const props = { logs, exitCode };

--- a/webpack/ForemanYupana/Components/Terminal/Terminal.js
+++ b/webpack/ForemanYupana/Components/Terminal/Terminal.js
@@ -19,7 +19,7 @@ class Terminal extends React.Component {
   };
 
   render() {
-    const { loading, logs, error } = this.props;
+    const { logs, error, exitCode } = this.props;
     let modifiedLogs = null;
     if (error !== null) {
       modifiedLogs = <p className="terminal_error">{error}</p>;
@@ -28,6 +28,7 @@ class Terminal extends React.Component {
     } else {
       modifiedLogs = <p>{logs}</p>;
     }
+    const loading = exitCode.toLowerCase().indexOf('running') !== -1;
     return (
       <Grid.Col sm={12}>
         <div className="terminal" ref={this.terminal}>
@@ -50,14 +51,14 @@ Terminal.propTypes = {
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.string,
   ]),
-  loading: PropTypes.bool,
   error: PropTypes.string,
+  exitCode: PropTypes.string,
 };
 
 Terminal.defaultProps = {
   logs: null,
-  loading: false,
   error: null,
+  exitCode: '',
 };
 
 export default Terminal;


### PR DESCRIPTION
Instead of showing a black screen, while exitCode is running, show the loading spinner:

![Selection_182](https://user-images.githubusercontent.com/26363699/62423360-8e61cf80-b6c8-11e9-8a1a-30e27c8fb012.png)

removed the loading prop as it wasn't used.
