### PR TITLE
Change Yupana menu button icon and text

### DIFF
--- a/lib/foreman_yupana/engine.rb
+++ b/lib/foreman_yupana/engine.rb
@@ -32,7 +32,7 @@ module ForemanYupana
         role 'ForemanYupana', [:view_foreman_yupana]
 
         # Adding a sub menu after hosts menu
-        sub_menu :top_menu, :Yupana, :caption => N_('Yupana'), :icon => 'fa fa-align-justify' do
+        sub_menu :top_menu, :Yupana, :caption => N_('RH Inventory'), :icon => 'fa fa-cloud-upload' do
           menu :top_menu, :level1, :caption => N_('Manage'), :url_hash => { controller: :'foreman_yupana/react', :action=>:index}
         end
 


### PR DESCRIPTION
Change it into something that makes more sense:

![Selection_184](https://user-images.githubusercontent.com/26363699/62423613-485a3b00-b6cb-11e9-88de-b3d76aa576b9.png)

I tried to enter "Inventory Uploads" though it was too long..