### PR TITLE
Fix logs polling lagging when switching between tabs

### DIFF
--- a/webpack/ForemanYupana/Components/Dashboard/Dashboard.js
+++ b/webpack/ForemanYupana/Components/Dashboard/Dashboard.js
@@ -29,9 +29,10 @@ class Dashboard extends React.Component {
     restartProcess(accountID);
   };
 
-  handleTabChange = tabName => {
-    const { setActiveTab, accountID } = this.props;
-    setActiveTab(accountID, tabName);
+  handleTabChange = async tabName => {
+    const { setActiveTab, accountID, fetchLogs } = this.props;
+    await setActiveTab(accountID, tabName);
+    fetchLogs(accountID);
   };
 
   render() {


### PR DESCRIPTION
You can see the logs immediately on switching tabs, instead of waiting 5 seconds 
![https___centos7-luna-devel rlavi example com_foreman_yupana_index](https://user-images.githubusercontent.com/26363699/62425465-10f78880-b6e3-11e9-93f6-a43c2308f4e4.gif)
